### PR TITLE
feat: export api.tpl and body.tpl to ygt.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y2tx",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Yapi 生成 Typescript`请求方法`及`声明文件`工具",
   "main": "lib/core/core.js",
   "types": "lib/core/src/core.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y2tx",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Yapi 生成 Typescript`请求方法`及`声明文件`工具",
   "main": "lib/core/core.js",
   "types": "lib/core/src/core.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "y2tx",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Yapi 生成 Typescript`请求方法`及`声明文件`工具",
   "main": "lib/core/core.js",
   "types": "lib/core/src/core.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "y2t",
-  "version": "0.0.2",
+  "name": "y2tx",
+  "version": "0.0.5",
   "description": "Yapi 生成 Typescript`请求方法`及`声明文件`工具",
   "main": "lib/core/core.js",
   "types": "lib/core/src/core.d.ts",

--- a/src/generate/interface.ts
+++ b/src/generate/interface.ts
@@ -20,7 +20,7 @@ import { IApiDetailParam, IApiInfoResponse } from '../typing/yapi'
  */
 export function generateInterface (apis: IApiInfoResponse[], projectName: string, projectId: number, basePath: string, modularId: number, onProgress?: () => void) {
   const config = getConfig()
-  const apiTemplate = fs.readFileSync(path.join(__dirname, '../templates/apiTemplate/api.tpl')).toString()
+  const apiTemplate = config.apiTpl? config.apiTpl:fs.readFileSync(path.join(__dirname, '../templates/apiTemplate/api.tpl')).toString()
   if (!(projectId in config.projectMapping)) {
     throw new Error(`生成失败，项目：${projectName}，ID：${projectId} 未配置 projectMapping`)
   }
@@ -101,7 +101,7 @@ export function generateInterface (apis: IApiInfoResponse[], projectName: string
 // 生成Api请求方法
 function generateApiFunction (api: IApiInfoResponse, projectName: string, projectId: number) {
   const config = getConfig()
-  const apiBodyTemplate = fs.readFileSync(path.join(__dirname, '../templates/apiTemplate/body.tpl')).toString()
+  const apiBodyTemplate = config.bodyTpl? config.bodyTpl : fs.readFileSync(path.join(__dirname, '../templates/apiTemplate/body.tpl')).toString()
   // 获取命名空间名
   const namespaceName = getNamespace(projectName)
   // 是否需要body
@@ -130,6 +130,7 @@ function generateApiFunction (api: IApiInfoResponse, projectName: string, projec
   const url = api.path.replace(/{(.*?)}/g, '${$1}')
   // 请求Body
   const bodyParam = isNeedBody ? api.detail.body ? 'body,' : 'undefined,' : ''
+  const dataParam = (isNeedBody && api.detail.body) ? 'data: body,' : ''
   // 请求Query
   const queryParam = api.detail.query && api.detail.query.length > 0 ? 'params: query' : ''
   const bodyContent = apiBodyTemplate.replace('{Description}', description)
@@ -142,6 +143,7 @@ function generateApiFunction (api: IApiInfoResponse, projectName: string, projec
     .replace('{Method}', method)
     .replace('{Url}', url)
     .replace('{BodyParam}', bodyParam)
+    .replace('{DataParam}', dataParam)
     .replace('{QueryParam}', queryParam)
   return bodyContent
 }

--- a/src/generate/interface.ts
+++ b/src/generate/interface.ts
@@ -106,6 +106,8 @@ function generateApiFunction (api: IApiInfoResponse, projectName: string, projec
   const namespaceName = getNamespace(projectName)
   // 是否需要body
   const isNeedBody = ['post', 'put'].includes(api.method.toLocaleLowerCase())
+  const tag = api.tag?api.tag.join():''
+  const tagParam = tag?`tag: ${tag}`: ''
   // 接口描述
   const description = api.title
   // 接口名字
@@ -134,6 +136,8 @@ function generateApiFunction (api: IApiInfoResponse, projectName: string, projec
   // 请求Query
   const queryParam = api.detail.query && api.detail.query.length > 0 ? 'params: query' : ''
   const bodyContent = apiBodyTemplate.replace('{Description}', description)
+    .replace('{tag}', tag)
+    .replace('{tagParam}', tagParam)
     .replace('{InterfaceName}', `${interfaceName}${response === 'T' ? '<T = any>' : ''}`)
     .replace('{UrlParams}', urlParams)
     .replace('{Query}', query)

--- a/src/typing/config.ts
+++ b/src/typing/config.ts
@@ -8,6 +8,8 @@ export interface IProjectMapping {
 
 // 配置文件
 export interface IConfig {
+  // token
+  token: string,
   // 账号
   account: string,
   // api 模板

--- a/src/typing/config.ts
+++ b/src/typing/config.ts
@@ -10,6 +10,10 @@ export interface IProjectMapping {
 export interface IConfig {
   // 账号
   account: string,
+  // api 模板
+  apiTpl: string,
+  // body 模板
+  bodyTpl: string,
   // 密码
   password: string,
   // 原地址

--- a/src/typing/yapi.ts
+++ b/src/typing/yapi.ts
@@ -28,6 +28,7 @@ export interface IApiInfoList {
 // api信息返回信息
 export interface IApiInfoResponse {
   id: number,
+  tag: string[],
   title: string,
   path: string,
   method: string,

--- a/src/yapi/api.ts
+++ b/src/yapi/api.ts
@@ -60,7 +60,7 @@ export async function getApiDetail (apiId: number): Promise<IApiDetailResult> {
       }
       // 解析Body
       try {
-        body = apiDetail?.req_body_other ? JSON.parse(apiDetail.req_body_other) : undefined
+        body = apiDetail?.req_body_other ? JSON.parse(replace$(apiDetail.req_body_other)) : undefined
       } catch (err) {
         response = undefined
         success = false

--- a/src/yapi/api.ts
+++ b/src/yapi/api.ts
@@ -32,6 +32,10 @@ export async function getApiList (modularId: number): Promise<IApiInfoResponse[]
   })
 }
 
+const replace$ = function (str:string) {
+  return str.replace(/\"\$ref/g,'"$$$ref')
+}
+
 // 获取api详情
 export async function getApiDetail (apiId: number): Promise<IApiDetailResult> {
   return new Promise((resolve) => {
@@ -48,7 +52,7 @@ export async function getApiDetail (apiId: number): Promise<IApiDetailResult> {
       // 解析Response
       try {
         // FIX FOR YAPI: https://github.com/SewerKing/y2t/issues/7
-        response = apiDetail?.res_body ? JSON.parse(apiDetail.res_body.replaceAll('"$ref','"$$ref')) : undefined
+        response = apiDetail?.res_body ? JSON.parse(replace$(apiDetail.res_body)) : undefined
       } catch (err) {
         response = undefined
         success = false

--- a/src/yapi/api.ts
+++ b/src/yapi/api.ts
@@ -47,7 +47,8 @@ export async function getApiDetail (apiId: number): Promise<IApiDetailResult> {
       let response
       // 解析Response
       try {
-        response = apiDetail?.res_body ? JSON.parse(apiDetail.res_body) : undefined
+        // FIX FOR YAPI: https://github.com/SewerKing/y2t/issues/7
+        response = apiDetail?.res_body ? JSON.parse(apiDetail.res_body.replaceAll('"$ref','"$$ref')) : undefined
       } catch (err) {
         response = undefined
         success = false

--- a/src/yapi/api.ts
+++ b/src/yapi/api.ts
@@ -16,6 +16,7 @@ export async function getApiList (modularId: number): Promise<IApiInfoResponse[]
         const detail = await getApiDetail(item._id)
         apiList.push({
           id: item._id,
+          tag: item.tag,
           title: item.title,
           path: item.path,
           method: item.method,

--- a/src/yapi/login.ts
+++ b/src/yapi/login.ts
@@ -7,6 +7,11 @@ export async function Login (): Promise<void> {
   return new Promise((resolve, reject) => {
     // 登录
     clg('yellow', '> yapi登录中...')
+    if(config.token){
+      clg('yellow', '> token登录中...')
+      setCookie(config.token)
+      return resolve()
+    }
     // 请求yapi登录接口，获取cookie
     http.post('/api/user/login', {
       email: config.account,


### PR DESCRIPTION
add support key 'apiTpl' and 'bodyTpl' in ygt.config.js
```
module.exports = {
  // 账号
  account: 'xx@xxx.com',
  // 密码
  password: '123456',
  // Yapi网址链接
  originUrl: 'https://xxx.com/',
  ...,
  apiTpl: `{Ignore}{dtsModule}
  import request from '{RequestFilePath}';
  {Wrapper}
  const MockUrl = '{Mock}';`,
  bodyTpl: `/**
  * {Description}
  */
  export function {InterfaceName}(
   {UrlParams}{Query}{Body}configs?: RequestConfig,
   isMock?:boolean ): RequestPromise<{Response}> {
   return {Mapping}({
     ...configs,
     url: isMock && MockUrl ? MockUrl : '{Url}',
     method: "{Method}",
     {DataParam}
     {QueryParam}
   });
 }
 `
};

```